### PR TITLE
workaround for foreign on cluster

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '587884'
+ValidationKey: '606944'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "piktests: Run PIK Integration Tests",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "<p>This package includes integration tests for selected models and packages related to those models.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: piktests
 Type: Package
-Version: 0.3.1
-Date: 2021-12-03
+Version: 0.3.2
+Date: 2021-12-06
 Title: Run PIK Integration Tests
 Description: This package includes integration tests for selected models and packages related to those models.
 Authors@R: c(person("Pascal", "Führlich", email = "pascal.fuehrlich@pik-potsdam.de", role = c("aut","cre")))

--- a/R/run.R
+++ b/R/run.R
@@ -24,7 +24,6 @@ run <- function(useSbatch, madratConfig, runFolder) {
   saveRDS(madratConfig, file.path(runFolder, "madratConfig.rds"))
 
   # magpie preprocessing
-  dir.create(file.path(runFolder, "preprocessings", "magpie"), recursive = TRUE)
   with_dir(file.path(runFolder, "preprocessings", "magpie"), {
     preprocessingMagpie(madratConfig, useSbatch, runFolder)
   })

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Run PIK Integration Tests
 
-R package **piktests**, version **0.3.1**
+R package **piktests**, version **0.3.2**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/piktests)](https://cran.r-project.org/package=piktests)  [![R build status](https://github.com/pik-piam/piktests/workflows/check/badge.svg)](https://github.com/pik-piam/piktests/actions) [![codecov](https://codecov.io/gh/pik-piam/piktests/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/piktests) 
+[![CRAN status](https://www.r-pkg.org/badges/version/piktests)](https://cran.r-project.org/package=piktests)  [![R build status](https://github.com/pik-piam/piktests/workflows/check/badge.svg)](https://github.com/pik-piam/piktests/actions) [![codecov](https://codecov.io/gh/pik-piam/piktests/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/piktests) [![r-universe](https://pik-piam.r-universe.dev/badges/piktests)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Pascal Führlich <pascal.fuehrlic
 
 To cite package **piktests** in publications use:
 
-Führlich P (2021). _piktests: Run PIK Integration Tests_. R package version 0.3.1, <URL: https://github.com/pik-piam/piktests>.
+Führlich P (2021). _piktests: Run PIK Integration Tests_. R package version 0.3.2, <URL: https://github.com/pik-piam/piktests>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {piktests: Run PIK Integration Tests},
   author = {Pascal Führlich},
   year = {2021},
-  note = {R package version 0.3.1},
+  note = {R package version 0.3.2},
   url = {https://github.com/pik-piam/piktests},
 }
 ```


### PR DESCRIPTION
The most recent `foreign` (0.8-81) requires R >= 4.0 which is not available on the cluster. `renv` tries to install the newest package versions and crashes, because `foreign` is not available. With this PR `piktests` installs `foreign@0.8-76` explicitly which works with R 3.6