### PR TITLE
compare renv.lock and log at once

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1638644'
+ValidationKey: '1658133'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "piktests: Run PIK Integration Tests",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "<p>This package includes integration tests for selected models\n    and packages related to those models.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piktests
 Title: Run PIK Integration Tests
-Version: 0.8.6
-Date: 2022-03-03
+Version: 0.8.7
+Date: 2022-03-08
 Authors@R: 
     c(person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = c("aut", "cre")),
       person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"))

--- a/R/runWithComparison.R
+++ b/R/runWithComparison.R
@@ -41,11 +41,12 @@ runWithComparison <- function(renvInstallPackages,
 
     # remove file hashes and runtimes before comparing
     writeLines(c("#!/usr/bin/env sh",
-                 paste(diffTool, paste0("'", file.path(runFolder, c("old", "new"), "renv.lock"), "'", collapse = " ")),
                  "oldLog=$(mktemp)",
                  "newLog=$(mktemp)",
-                 paste0("sed -r 's/in [0-9.]+ (seconds|Minutes\")$//g' '", oldLog, "' > $oldLog"),
-                 paste0("sed -r 's/in [0-9.]+ (seconds|Minutes\")$//g' '", newLog, "' > $newLog"),
+                 paste0("cp '", file.path(runFolder, "old", "renv.lock"), "' $oldLog"),
+                 paste0("cp '", file.path(runFolder, "new", "renv.lock"), "' $newLog"),
+                 paste0("sed -r 's/in [0-9.]+ (seconds|Minutes\")$//g' '", oldLog, "' >> $oldLog"),
+                 paste0("sed -r 's/in [0-9.]+ (seconds|Minutes\")$//g' '", newLog, "' >> $newLog"),
                  paste0(diffTool, " $oldLog $newLog"),
                  "rm $oldLog $newLog"),
                compareLogsPath)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run PIK Integration Tests
 
-R package **piktests**, version **0.8.6**
+R package **piktests**, version **0.8.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piktests)](https://cran.r-project.org/package=piktests)  [![R build status](https://github.com/pik-piam/piktests/workflows/check/badge.svg)](https://github.com/pik-piam/piktests/actions) [![codecov](https://codecov.io/gh/pik-piam/piktests/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piktests) [![r-universe](https://pik-piam.r-universe.dev/badges/piktests)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Pascal Führlich <pascal.fuehrlic
 
 To cite package **piktests** in publications use:
 
-Führlich P, Dietrich J (2022). _piktests: Run PIK Integration Tests_. R package version 0.8.6, <URL: https://github.com/pik-piam/piktests>.
+Führlich P, Dietrich J (2022). _piktests: Run PIK Integration Tests_. R package version 0.8.7, <URL: https://github.com/pik-piam/piktests>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {piktests: Run PIK Integration Tests},
   author = {Pascal Führlich and Jan Philipp Dietrich},
   year = {2022},
-  note = {R package version 0.8.6},
+  note = {R package version 0.8.7},
   url = {https://github.com/pik-piam/piktests},
 }
 ```


### PR DESCRIPTION
renv.lock and logfile are now merged before comparing. Before they were compared separately, but the first comparison was only visible for <1sec before the second comparison was shown.