### PR TITLE
alternative input for computations argument

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1718640'
+ValidationKey: '1738464'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "piktests: Run PIK Integration Tests",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "<p>This package includes integration tests for selected models\n    and packages related to those models.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piktests
 Title: Run PIK Integration Tests
-Version: 0.9.0
-Date: 2022-04-14
+Version: 0.9.1
+Date: 2022-04-22
 Authors@R: 
     c(person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = c("aut", "cre")),
       person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"))

--- a/R/baseComputations.R
+++ b/R/baseComputations.R
@@ -44,6 +44,9 @@ baseComputations <- list(
   ),
   testComputation = list(
     setup = function() {
+      if (!is.null(renv::project())) {
+        renv::settings$use.cache(FALSE)
+      }
       file.create("setupComplete")
     },
      compute = function() {

--- a/R/run.R
+++ b/R/run.R
@@ -43,11 +43,12 @@ run <- function(renvInstallPackages = NULL,
                 executionMode = c("slurm", "directly"),
                 localCache = TRUE) {
 
-  if (!is.list(computations)) {
+  if (is.character(computations)) {
     if (all(computations %in% names(baseComputations))) {
       computations <- baseComputations[computations]
     } else {
-      stop("Computations provided in an incompatible format!")
+      stop("Unknown computations provided: [", paste(setdiff(computations, names(baseComputations)), collapse = ", "),
+           "] - Available computations: [", paste(names(baseComputations), collapse = ", "), "]")
     }
   }
   runFolder <- createRunFolder(names(computations), piktestsFolder, runFolder)

--- a/R/run.R
+++ b/R/run.R
@@ -7,7 +7,8 @@
 #'
 #' @param renvInstallPackages After installing other packages, renv::install(renvInstallPackages) is called.
 #' Use this to test changes in your fork by passing "<gituser>/<repo>" (e.g. "pfuehrlich-pik/madrat").
-#' @param computations A named list of "computations". A computation consists of a setup and a compute function.
+#' @param computations A named list of "computations", or names of computations predefined in
+#' \code{\link{baseComputations}}. A computation consists of a setup and a compute function.
 #' See example for a valid computation list.
 #' @param piktestsFolder A new folder for this piktests run is created in the given directory.
 #' @param runFolder Path where a folder for this piktests run should be created. Generally should be left as default,
@@ -35,12 +36,20 @@
 #' @importFrom withr with_output_sink
 #' @export
 run <- function(renvInstallPackages = NULL,
-                computations = baseComputations[c("magpiePrep", "remindPrep")],
+                computations = c("magpiePrep", "remindPrep"),
                 piktestsFolder = getwd(),
                 runFolder = NULL,
                 jobNameSuffix = "",
                 executionMode = c("slurm", "directly"),
                 localCache = TRUE) {
+
+  if (!is.list(computations)) {
+    if (all(computations %in% names(baseComputations))) {
+      computations <- baseComputations[computations]
+    } else {
+      stop("Computations provided in an incompatible format!")
+    }
+  }
   runFolder <- createRunFolder(names(computations), piktestsFolder, runFolder)
 
   with_output_sink(file.path(runFolder, "piktestsSetup.log"), split = TRUE, code = {

--- a/R/runWithComparison.R
+++ b/R/runWithComparison.R
@@ -27,11 +27,12 @@ runWithComparison <- function(renvInstallPackages,
                               piktestsFolder = getwd(),
                               diffTool = c("delta", "colordiff", "diff"), ...) {
   stopifnot(!is.null(renvInstallPackages))
-  if (!is.list(computations)) {
+  if (is.character(computations)) {
     if (all(computations %in% names(baseComputations))) {
       computations <- baseComputations[computations]
     } else {
-      stop("Computations provided in an incompatible format!")
+      stop("Unknown computations provided: [", paste(setdiff(computations, names(baseComputations)), collapse = ", "),
+           "] - Available computations: [", paste(names(baseComputations), collapse = ", "), "]")
     }
   }
   runFolder <- createRunFolder(names(computations), piktestsFolder)

--- a/R/runWithComparison.R
+++ b/R/runWithComparison.R
@@ -6,7 +6,8 @@
 #'
 #' @param renvInstallPackages Only in the second run, after installing other
 #' packages, `renv::install(renvInstallPackages)` is called.
-#' @param computations A named list of "computations". A computation consists of a setup and a compute function.
+#' @param computations A named list of "computations", or names of computations predefined in
+#' \code{\link{baseComputations}}. A computation consists of a setup and a compute function.
 #' See example for a valid computation list.
 #' @param piktestsFolder A new folder is created in the given directory. In that folder two folders called "old"
 #' and "new" are created which contain the actual piktests runs.
@@ -22,10 +23,17 @@
 #' @importFrom utils head
 #' @export
 runWithComparison <- function(renvInstallPackages,
-                              computations = baseComputations[c("magpiePrep", "remindPrep")],
+                              computations = c("magpiePrep", "remindPrep"),
                               piktestsFolder = getwd(),
                               diffTool = c("delta", "colordiff", "diff"), ...) {
   stopifnot(!is.null(renvInstallPackages))
+  if (!is.list(computations)) {
+    if (all(computations %in% names(baseComputations))) {
+      computations <- baseComputations[computations]
+    } else {
+      stop("Computations provided in an incompatible format!")
+    }
+  }
   runFolder <- createRunFolder(names(computations), piktestsFolder)
   run(renvInstallPackages = NULL, computations = computations, ...,
       runFolder = file.path(runFolder, "old"), jobNameSuffix = "-old")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run PIK Integration Tests
 
-R package **piktests**, version **0.9.0**
+R package **piktests**, version **0.9.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piktests)](https://cran.r-project.org/package=piktests)  [![R build status](https://github.com/pik-piam/piktests/workflows/check/badge.svg)](https://github.com/pik-piam/piktests/actions) [![codecov](https://codecov.io/gh/pik-piam/piktests/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piktests) [![r-universe](https://pik-piam.r-universe.dev/badges/piktests)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Pascal Führlich <pascal.fuehrlic
 
 To cite package **piktests** in publications use:
 
-Führlich P, Dietrich J (2022). _piktests: Run PIK Integration Tests_. R package version 0.9.0, <URL: https://github.com/pik-piam/piktests>.
+Führlich P, Dietrich J (2022). _piktests: Run PIK Integration Tests_. R package version 0.9.1, <URL: https://github.com/pik-piam/piktests>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {piktests: Run PIK Integration Tests},
   author = {Pascal Führlich and Jan Philipp Dietrich},
   year = {2022},
-  note = {R package version 0.9.0},
+  note = {R package version 0.9.1},
   url = {https://github.com/pik-piam/piktests},
 }
 ```

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -6,7 +6,7 @@
 \usage{
 run(
   renvInstallPackages = NULL,
-  computations = baseComputations[c("magpiePrep", "remindPrep")],
+  computations = c("magpiePrep", "remindPrep"),
   piktestsFolder = getwd(),
   runFolder = NULL,
   jobNameSuffix = "",
@@ -18,7 +18,8 @@ run(
 \item{renvInstallPackages}{After installing other packages, renv::install(renvInstallPackages) is called.
 Use this to test changes in your fork by passing "<gituser>/<repo>" (e.g. "pfuehrlich-pik/madrat").}
 
-\item{computations}{A named list of "computations". A computation consists of a setup and a compute function.
+\item{computations}{A named list of "computations", or names of computations predefined in
+\code{\link{baseComputations}}. A computation consists of a setup and a compute function.
 See example for a valid computation list.}
 
 \item{piktestsFolder}{A new folder for this piktests run is created in the given directory.}

--- a/man/runWithComparison.Rd
+++ b/man/runWithComparison.Rd
@@ -6,7 +6,7 @@
 \usage{
 runWithComparison(
   renvInstallPackages,
-  computations = baseComputations[c("magpiePrep", "remindPrep")],
+  computations = c("magpiePrep", "remindPrep"),
   piktestsFolder = getwd(),
   diffTool = c("delta", "colordiff", "diff"),
   ...
@@ -16,7 +16,8 @@ runWithComparison(
 \item{renvInstallPackages}{Only in the second run, after installing other
 packages, `renv::install(renvInstallPackages)` is called.}
 
-\item{computations}{A named list of "computations". A computation consists of a setup and a compute function.
+\item{computations}{A named list of "computations", or names of computations predefined in
+\code{\link{baseComputations}}. A computation consists of a setup and a compute function.
 See example for a valid computation list.}
 
 \item{piktestsFolder}{A new folder is created in the given directory. In that folder two folders called "old"

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -7,7 +7,7 @@ test_that("run works", {
   expect_true(file.exists(file.path(runFolder, "madratConfig.rds")))
   expect_true(file.exists(file.path(runFolder, "optionsEnvironmentVariablesLocale.rds")))
   expect_true(file.exists(file.path(runFolder, "testComputation", "setupComplete")))
-  expect_equal(readLines(file.path(runFolder, "testComputation", "job.log")), "computation complete")
+  expect_true("computation complete" %in% readLines(file.path(runFolder, "testComputation", "job.log")))
   expect_true(dir.exists(file.path(runFolder, "renv")))
   expect_true(file.exists(file.path(runFolder, "renv.lock")))
 

--- a/tests/testthat/test-runLongJob.R
+++ b/tests/testthat/test-runLongJob.R
@@ -16,6 +16,7 @@ test_that("runLongJob works", {
   renvProject <- withr::local_tempdir()
   callr::r(function(targetDir) {
     renv::init(targetDir)
+    renv::settings$use.cache(FALSE)
     renv::install("withr")
   }, list(renvProject))
   workingDirectory <- withr::local_tempdir()


### PR DESCRIPTION
suggestion to simplify the input to the `computations` argument again for common cases. 

`buildLibrary` failed in my case claiming that `withr` would not be available even so it is installed. I am not sure how to handle it.