### PR TITLE
add remindModel and magpieModel computations

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1738464'
+ValidationKey: '1914200'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,14 @@
+# testthat snapshots are machine-generated regression tests that
+# have to be preserved exactly as they are
+exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
     -   id: check-yaml
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
-    -   id: end-of-file-fixer
 ci:
     autoupdate_schedule: quarterly

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "piktests: Run PIK Integration Tests",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "<p>This package includes integration tests for selected models\n    and packages related to those models.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piktests
 Title: Run PIK Integration Tests
-Version: 0.9.1
-Date: 2022-04-22
+Version: 0.10.0
+Date: 2022-05-30
 Authors@R: 
     c(person("Pascal", "Führlich", , "pascal.fuehrlich@pik-potsdam.de", role = c("aut", "cre")),
       person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"))

--- a/R/baseComputations.R
+++ b/R/baseComputations.R
@@ -70,7 +70,7 @@ baseComputations <- list(
     compute = function() {
       withr::local_dir("repo")
       stopifnot(Sys.info()[["user"]] != "unknown")
-      modelstats::modeltests(model = "MAgPIE", user = Sys.info()[["user"]],
+      modelstats::modeltests(mydir = normalizePath("."), model = "MAgPIE", user = Sys.info()[["user"]],
                              compScen = FALSE, iamccheck = FALSE, email = FALSE)
     }
   ),

--- a/R/baseComputations.R
+++ b/R/baseComputations.R
@@ -38,35 +38,40 @@ baseComputations <- list(
   remindModel = list(
     setup = function() {
       message("Cloning the REMIND model repository, please wait...")
-      # TODO switch to remindmodel/remind
-      gert::git_clone("https://github.com/pfuehrlich-pik/remindmodel", branch = "develop", path = "repo")
+      gert::git_clone("https://github.com/remindmodel/remind", branch = "develop", path = "repo")
 
       renvProject <- normalizePath("..")
-      writeLines(paste0("renv::load('", renvProject, "')"),
+      writeLines(c(paste0("renv::load('", renvProject, "')"),
+                   "stopifnot(!is.null(renv::project()))"),
                  file.path("repo", ".Rprofile"))
+
+      renv::install("modelstats")
+      writeLines("start", file.path("repo", ".testsstatus")) # needed for modelstats
     },
     compute = function() {
       withr::local_dir("repo")
-      system2("Rscript", "start.R", input = "5") # 5 = SLURM priority, 12 nodes, nash H12
+      stopifnot(Sys.info()[["user"]] != "unknown")
+      modelstats::modeltests(model = "REMIND", user = Sys.info()[["user"]],
+                             compScen = FALSE, iamccheck = FALSE, email = FALSE)
     }
   ),
   magpieModel = list(
     setup = function() {
       gert::git_clone("https://github.com/magpiemodel/magpie", branch = "develop", path = "repo")
 
-      # TODO remove this file.remove when lucode is no longer used in these scripts
-      # delete scripts that use the unavailable lucode package
-      file.remove(file.path("repo", "scripts", "start", "projects", c("aff_bgp.R",
-                                                                      "project_BEST.R",
-                                                                      "project_inms2.R")))
-
       renvProject <- normalizePath("..")
-      writeLines(paste0("renv::load('", renvProject, "')"),
+      writeLines(c(paste0("renv::load('", renvProject, "')"),
+                   "stopifnot(!is.null(renv::project()))"),
                  file.path("repo", ".Rprofile"))
+
+      renv::install("modelstats")
+      writeLines("start", file.path("repo", ".testsstatus")) # needed for modelstats
     },
     compute = function() {
       withr::local_dir("repo")
-      source(file.path("scripts", "start", "default.R")) # nolint
+      stopifnot(Sys.info()[["user"]] != "unknown")
+      modelstats::modeltests(model = "MAgPIE", user = Sys.info()[["user"]],
+                             compScen = FALSE, iamccheck = FALSE, email = FALSE)
     }
   ),
   edgebuildingsPrep = list(

--- a/R/setupRenv.R
+++ b/R/setupRenv.R
@@ -41,7 +41,10 @@ setupRenv <- function(targetFolder, renvInstallPackages, computationsSourceCode)
     renv::install(renvInstallPackages)
   }
 
-  renv::install("withr")
+  # withr is used to make temporary changes to global state like working directory, used in computations
+  # gert is used to clone repos in many computation setup functions
+  # yaml is needed so renv can determine dependencies in Rmd files
+  renv::install(c("withr", "gert", "yaml"))
 
   if (!is.null(renvInstallPackages)) {
     renv::install(renvInstallPackages)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run PIK Integration Tests
 
-R package **piktests**, version **0.9.1**
+R package **piktests**, version **0.10.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piktests)](https://cran.r-project.org/package=piktests)  [![R build status](https://github.com/pik-piam/piktests/workflows/check/badge.svg)](https://github.com/pik-piam/piktests/actions) [![codecov](https://codecov.io/gh/pik-piam/piktests/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piktests) [![r-universe](https://pik-piam.r-universe.dev/badges/piktests)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Pascal Führlich <pascal.fuehrlic
 
 To cite package **piktests** in publications use:
 
-Führlich P, Dietrich J (2022). _piktests: Run PIK Integration Tests_. R package version 0.9.1, <URL: https://github.com/pik-piam/piktests>.
+Führlich P, Dietrich J (2022). _piktests: Run PIK Integration Tests_. R package version 0.10.0, <URL: https://github.com/pik-piam/piktests>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {piktests: Run PIK Integration Tests},
   author = {Pascal Führlich and Jan Philipp Dietrich},
   year = {2022},
-  note = {R package version 0.9.1},
+  note = {R package version 0.10.0},
   url = {https://github.com/pik-piam/piktests},
 }
 ```

--- a/man/baseComputations.Rd
+++ b/man/baseComputations.Rd
@@ -5,7 +5,7 @@
 \alias{baseComputations}
 \title{baseComputations}
 \format{
-An object of class \code{list} of length 5.
+An object of class \code{list} of length 7.
 }
 \usage{
 baseComputations


### PR DESCRIPTION
Both magpie and reming are started via `modelstats::modeltests`, the same function that runs the AMTs.